### PR TITLE
Update maxConstraints in DraggableComponent based on component type

### DIFF
--- a/src/components/builder/DraggableComponent.tsx
+++ b/src/components/builder/DraggableComponent.tsx
@@ -341,7 +341,10 @@ const DraggableComponent: React.FC<DraggableComponentProps> = ({ component, isEd
           component.type === 'button' ? 80 : 200,
           component.type === 'button' ? 32 : (component.type === 'scorecard' ? 120 : 100)
         ]}
-        maxConstraints={[800, 600]}
+        maxConstraints={[
+          component.type === 'table' ? 2000 : 800,
+          1600
+        ]}
         className="canvas-component"
         handle={<div className="react-resizable-handle" />}
       >


### PR DESCRIPTION
- Adjusted the maxConstraints property to dynamically set the maximum width for 'table' components to 2000, while maintaining a limit of 800 for other types.
- Increased the maximum height constraint to a fixed value of 1600 for all component types.

These changes improve the flexibility of the DraggableComponent, allowing for better layout management based on the specific component type.