### PR TITLE
Implement reserved word validation for table fields in TableBuilder

### DIFF
--- a/src/components/database/TableBuilder.tsx
+++ b/src/components/database/TableBuilder.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { X, Plus, Trash2 } from 'lucide-react';
 import { createDatabaseTable } from '../../services/api/database';
+import { isReservedWord } from '../../utils/database';
 
 interface TableBuilderProps {
   onClose: () => void;
@@ -41,6 +42,16 @@ const TableBuilder: React.FC<TableBuilderProps> = ({ onClose, onSubmit, onTableC
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    
+    // Validate field names for reserved words before creating table
+    const reservedWordFields = fields.filter(field => isReservedWord(field.name));
+    
+    if (reservedWordFields.length > 0) {
+      const fieldNames = reservedWordFields.map(f => `"${f.name}"`).join(', ');
+      setError(`Cannot create table: ${fieldNames} ${reservedWordFields.length > 1 ? 'are' : 'is'} PostgreSQL reserved ${reservedWordFields.length > 1 ? 'words' : 'word'}. Please choose different field names.`);
+      return;
+    }
+
     await handleCreateTable(tableName, fields);
     onClose();
   };

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -26,3 +26,22 @@ export const isValidTableName = (tableName: string): boolean => {
   const validPattern = /^[a-zA-Z][a-zA-Z0-9_]*$/;
   return validPattern.test(tableName);
 };
+
+const POSTGRESQL_RESERVED_WORDS = [
+  'all', 'analyse', 'analyze', 'and', 'any', 'array', 'as', 'asc', 'asymmetric',
+  'authorization', 'between', 'binary', 'both', 'case', 'cast', 'check', 'collate',
+  'column', 'constraint', 'create', 'cross', 'current_date', 'current_role',
+  'current_time', 'current_timestamp', 'current_user', 'default', 'deferrable',
+  'desc', 'distinct', 'do', 'else', 'end', 'except', 'false', 'for', 'foreign',
+  'freeze', 'from', 'full', 'grant', 'group', 'having', 'ilike', 'in', 'initially',
+  'inner', 'intersect', 'into', 'is', 'isnull', 'join', 'leading', 'left', 'like',
+  'limit', 'localtime', 'localtimestamp', 'natural', 'not', 'notnull', 'null',
+  'offset', 'on', 'only', 'or', 'order', 'outer', 'overlaps', 'placing', 'primary',
+  'references', 'right', 'select', 'session_user', 'similar', 'some', 'symmetric',
+  'table', 'then', 'to', 'trailing', 'true', 'union', 'unique', 'user', 'using',
+  'verbose', 'when', 'where', 'with'
+];
+
+export const isReservedWord = (word: string): boolean => {
+  return POSTGRESQL_RESERVED_WORDS.includes(word.toLowerCase());
+};


### PR DESCRIPTION
- Added a utility function to check for PostgreSQL reserved words.
- Integrated validation logic in the TableBuilder component to prevent the creation of tables with fields named after reserved words.
- Enhanced user feedback by displaying an error message when reserved words are detected.

These changes improve data integrity and user experience by ensuring that table field names do not conflict with database constraints.